### PR TITLE
RELIABILITY_QOS_POLICY for camera_info

### DIFF
--- a/isaac_ros_visual_slam/src/visual_slam_node.cpp
+++ b/isaac_ros_visual_slam/src/visual_slam_node.cpp
@@ -76,11 +76,11 @@ VisualSlamNode::VisualSlamNode(rclcpp::NodeOptions options)
   left_image_sub_(message_filters::Subscriber<sensor_msgs::msg::Image>(
       this, "stereo_camera/left/image", image_qos_)),
   left_camera_info_sub_(message_filters::Subscriber<sensor_msgs::msg::CameraInfo>(
-      this, "stereo_camera/left/camera_info")),
+      this, "stereo_camera/left/camera_info", image_qos_)),
   right_image_sub_(message_filters::Subscriber<sensor_msgs::msg::Image>(
       this, "stereo_camera/right/image", image_qos_)),
   right_camera_info_sub_(message_filters::Subscriber<sensor_msgs::msg::CameraInfo>(
-      this, "stereo_camera/right/camera_info")),
+      this, "stereo_camera/right/camera_info", image_qos_)),
   imu_sub_(create_subscription<sensor_msgs::msg::Imu>(
       "visual_slam/imu", rclcpp::QoS(100),
       std::bind(&VisualSlamNode::ReadImuData, this, std::placeholders::_1))),


### PR DESCRIPTION
Component container return below message when work on Gazebo simulation:
[component_container-1] [WARN] [1662381267.101849583] [visual_slam_node]: New publisher discovered on topic '/infra2/camera_info', offering incompatible QoS. No messages will be sent to it. Last incompatible policy: RELIABILITY_QOS_POLICY

So, i add image_qos_ to camera info.